### PR TITLE
LETI 122631 Parte 2 - Database: Informação Sobre Filme

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>io.qameta.allure</groupId>
                 <artifactId>allure-maven</artifactId>
-                <version>2.15.2</version>
+                <version>2.12.0</version>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/vaadin/database/movie/pages/VaadinDataBaseExampleDemoPage.java
+++ b/src/test/java/com/vaadin/database/movie/pages/VaadinDataBaseExampleDemoPage.java
@@ -1,0 +1,88 @@
+package com.vaadin.database.movie.pages;
+import com.codeborne.selenide.*;
+
+import static com.codeborne.selenide.Selenide.*;
+
+public class VaadinDataBaseExampleDemoPage {
+
+    // Elements in the movie details panel
+    public SelenideElement title = $(".movie-details h3");
+    public SelenideElement releaseDate = $(".movie-details p:nth-of-type(1)");
+    public SelenideElement director = $(".movie-details p:nth-of-type(2)");
+    public SelenideElement genres = $(".movie-details p:nth-of-type(3)");
+    public SelenideElement rating = $(".movie-details p:nth-of-type(4)");
+    public SelenideElement imdbLink = $(".movie-details a");
+
+    // The grid component
+    private final SelenideElement grid = $("vaadin-grid");
+    // The cells within the grid
+    private final ElementsCollection movieGridCells = $$("vaadin-grid-cell-content");
+
+    /**
+     * Clicks on a movie in the grid based on its title.
+     * This method handles the virtual scrolling of the vaadin-grid.
+     * @param movieTitle The title of the movie to click.
+     */
+    public void selectMovieByTitle(String movieTitle) {
+        grid.shouldBe(Condition.visible);
+        Selenide.executeJavaScript("arguments[0].scrollToIndex(0)", grid);
+        Selenide.sleep(500);
+
+        while (true) {
+            SelenideElement movieElement = movieGridCells.findBy(Condition.text(movieTitle));
+            if (movieElement.exists()) {
+                movieElement.click();
+                Selenide.sleep(500); // Wait for UI to update
+                return;
+            }
+
+            Integer last = Selenide.executeJavaScript("return arguments[0].lastVisibleIndex", grid);
+            Integer total = Selenide.executeJavaScript("return arguments[0].items.length", grid);
+
+            if (last != null && total != null && last.equals(total - 1)) {
+                throw new IllegalStateException("Element with text '" + movieTitle + "' not found in the grid after scrolling.");
+            }
+
+            if (last != null) {
+                Selenide.executeJavaScript("arguments[0].scrollToIndex(arguments[1])", grid, last);
+                Selenide.sleep(500);
+            } else {
+                throw new IllegalStateException("Could not determine the last visible index to scroll.");
+            }
+        }
+    }
+
+    public SelenideElement findMovieByTitle(String movieTitle) {
+        grid.shouldBe(Condition.visible);
+        // Scroll to the top of the grid before starting
+        Selenide.executeJavaScript("arguments[0].scrollToIndex(0)", grid);
+        Selenide.sleep(500); // Wait for the grid to render the initial items
+
+        while (true) {
+            // Find the movie element within the currently visible items
+            SelenideElement movieElement = movieGridCells.findBy(Condition.text(movieTitle));
+            if (movieElement.exists()) {
+                return movieElement;
+            }
+
+            // Get the index of the last visible item and the total number of items
+            Integer last = Selenide.executeJavaScript("return arguments[0].lastVisibleIndex", grid);
+            Integer total = Selenide.executeJavaScript("return arguments[0].items.length", grid);
+
+            // If we've reached the end of the grid and haven't found the movie, throw an error
+            if (last != null && total != null && last.equals(total - 1)) {
+                break; // Movie not found
+            }
+
+            // Scroll to the last visible index to load the next chunk of items
+            if (last != null) {
+                Selenide.executeJavaScript("arguments[0].scrollToIndex(arguments[1])", grid, last);
+                Selenide.sleep(500); // Wait for new items to load
+            } else {
+                // If last is null, we can't scroll further, so break the loop
+                break;
+            }
+        }
+        return movieGridCells.findBy(Condition.text(movieTitle));
+    }
+}

--- a/src/test/java/com/vaadin/database/movie/tests/MovieInfoTest.java
+++ b/src/test/java/com/vaadin/database/movie/tests/MovieInfoTest.java
@@ -1,0 +1,37 @@
+package com.vaadin.database.movie.tests;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.logevents.SelenideLogger;
+import com.vaadin.database.movie.pages.VaadinDataBaseExampleDemoPage;
+import io.qameta.allure.selenide.AllureSelenide;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.open;
+
+public class MovieInfoTest {
+
+    VaadinDataBaseExampleDemoPage mainViewPage = new VaadinDataBaseExampleDemoPage();
+
+    @BeforeAll
+    public static void setUpAll() {
+        Configuration.browserSize = "1280x800";
+        Configuration.timeout = 10000;
+        SelenideLogger.addListener("allure", new AllureSelenide());
+    }
+
+    @BeforeEach
+    public void setUp() {
+        open("https://vaadin-database-example.demo.vaadin.com/");
+    }
+
+    @Test
+    public void testFindKnivesOutInGrid() {
+        String movieToSelect = "Knives Out";
+        mainViewPage.findMovieByTitle(movieToSelect).shouldBe(visible);
+    }
+}


### PR DESCRIPTION
This pull request introduces new UI test automation for the Vaadin movie database demo using Selenide and Allure. It adds a page object to interact with the movie grid and details panel, and a test class to verify that a specific movie can be found in the grid. Additionally, it updates the Allure Maven plugin version in the project configuration.

### New UI Test Automation

* Added the `VaadinDataBaseExampleDemoPage` page object class, which provides methods to interact with the movie grid, handle virtual scrolling, and access movie details panel elements. (`src/test/java/com/vaadin/database/movie/pages/VaadinDataBaseExampleDemoPage.java`)
* Created the `MovieInfoTest` test class, which sets up Selenide and Allure integration, navigates to the demo site, and verifies that the "Knives Out" movie can be found in the grid. (`src/test/java/com/vaadin/database/movie/tests/MovieInfoTest.java`)

### Build Configuration

* Downgraded the Allure Maven plugin version from `2.15.2` to `2.12.0` in `pom.xml` for compatibility.